### PR TITLE
Allow the config key to be camelCase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ import styles from './style.css';
   }
 
   const install = function (hook, vm) {
-    const options = mergeObjects(CONFIG, vm.config['flexible-alerts']);
+    const options = mergeObjects(CONFIG, vm.config['flexible-alerts'] || vm.config.flexibleAlerts);
 
     const findSetting = function findAlertSetting(input, key, fallback, callback) {
       const match = (input || '').match(new RegExp(`${key}:(([\\s\\w\\u00A0-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFEF]*))`));


### PR DESCRIPTION
Today to configure this plugin, we need to set the key `"flexible-alert"` as a string.
It works and everything is fine but I prefer to use a `camelCased` key
This PR allows both config key to be valid.